### PR TITLE
Generalize LNDT to support any signature functor

### DIFF
--- a/Agda_lib/Dependencies/Imports.agda
+++ b/Agda_lib/Dependencies/Imports.agda
@@ -21,9 +21,13 @@ open import Function public
   using
     (_∘_ ; id ; const ; constᵣ ; flip ; _|>_ ; case_of_ ; _∘₂_ ; ∣_⟩-_)
 
+open import Data.Unit public
+  using
+    (⊤ ; tt)
+
 open import Data.Product public
   using
-    (_,_ ; ∃ ; _×_ ; proj₁ ; proj₂)
+    (Σ-syntax ; _,_ ; ∃ ; _×_ ; proj₁ ; proj₂)
 
 open import Data.Sum public
   using
@@ -41,7 +45,11 @@ open import Relation.Unary public
     
 open import Agda.Primitive public
   using
-    (Setω)
+    (Setω ; lsuc ; _⊔_)
+
+open import Level public
+  using
+    (Lift ; lift)
 
 open import Relation.Binary public
   using

--- a/Agda_lib/GNDT.agda
+++ b/Agda_lib/GNDT.agda
@@ -1,0 +1,72 @@
+module GNDT where
+
+open import Dependencies.Imports
+open import SpreadAble
+
+
+-- Pattern functors
+
+data Sig a : Set (lsuc a) where
+  `⊤ : Sig a
+  `K : Set a → Sig a
+  `X : Sig a
+  `A : Sig a
+  _`×_ : Sig a → Sig a → Sig a
+  _`⊎_ : Sig a → Sig a → Sig a
+
+⟦_⟧ : ∀ {a} → Sig a → Set a → Set a → Set a
+⟦ `⊤ ⟧ A X = Lift _ ⊤
+⟦ `K S ⟧ A X = S
+⟦ `X ⟧ A X = X
+⟦ `A ⟧ A X = A
+⟦ Σ₁ `× Σ₂ ⟧ A X = ⟦ Σ₁ ⟧ A X × ⟦ Σ₂ ⟧ A X
+⟦ Σ₁ `⊎ Σ₂ ⟧ A X = ⟦ Σ₁ ⟧ A X ⊎ ⟦ Σ₂ ⟧ A X
+
+⟦_⟧-map : ∀ {a}{A B X Y : Set a} → (Σ : Sig a) → (A → B) → (X → Y) → ⟦ Σ ⟧ A X → ⟦ Σ ⟧ B Y
+⟦ `⊤ ⟧-map f g t = t
+⟦ `K x ⟧-map f g k = k
+⟦ `X ⟧-map f g x = g x
+⟦ `A ⟧-map f g a = f a
+⟦ Σ₁ `× Σ₂ ⟧-map f g (xs₁ , xs₂) = ⟦ Σ₁ ⟧-map f g xs₁ , ⟦ Σ₂ ⟧-map f g xs₂
+⟦ Σ₁ `⊎ Σ₂ ⟧-map f g (inj₁ xs₁) = inj₁ (⟦ Σ₁ ⟧-map f g xs₁)
+⟦ Σ₁ `⊎ Σ₂ ⟧-map f g (inj₂ xs₂) = inj₂ (⟦ Σ₂ ⟧-map f g xs₂)
+
+□ : ∀ {a b}{A X : Set a} → (Σ : Sig a) → (X → Set b) → ⟦ Σ ⟧ A X → Set b
+□ `⊤ P t = Lift _ ⊤
+□ (`K x) P k = Lift _ ⊤
+□ `X P x = P x
+□ `A P a = Lift _ ⊤
+□ (Σ₁ `× Σ₂) P (xs₁ , xs₂) = □ Σ₁ P xs₁ × □ Σ₂ P xs₂
+□ (Σ₁ `⊎ Σ₂) P (inj₁ xs₁) = □ Σ₁ P xs₁
+□ (Σ₁ `⊎ Σ₂) P (inj₂ xs₂) = □ Σ₂ P xs₂
+
+-- The specification for generalized ndt data types
+
+SIG : Setω
+SIG = ∀ {a} → Sig a
+
+data GNDT {a} (Σ : SIG)(F : TT)(A : Set a) : Set a where
+  ctor : ⟦ Σ ⟧ A (GNDT Σ F (F A)) → GNDT Σ F A
+
+-- Induction principle over generalized ndt data types
+
+module Induction {Σ : SIG}{F : TT}
+                 {b}(P : ∀ {a}{A : Set a} → GNDT Σ F A → Set b)
+                 (ih : ∀ {a}{A : Set a} → (xs : ⟦ Σ ⟧ A (GNDT Σ F (F A))) → □ Σ P xs → P (ctor xs)) where
+
+       gndt-ind : ∀ {a}{A : Set a} (x : GNDT Σ F A) → P x
+
+       □-map : ∀ {a}(Σ' : Sig a){A : Set a}
+               (x : ⟦ Σ' ⟧ A (GNDT Σ F (F A))) → □ Σ' P x
+
+       gndt-ind (ctor x) = ih x (□-map Σ x)
+
+       □-map `⊤ t = lift tt
+       □-map (`K S) k = lift tt
+       □-map `X x = gndt-ind x
+       □-map `A a = lift tt
+       □-map (Σ₁ `× Σ₂) (xs₁ , xs₂) = □-map Σ₁ xs₁ , □-map Σ₂ xs₂
+       □-map (Σ₁ `⊎ Σ₂) (inj₁ xs₁) = □-map Σ₁ xs₁
+       □-map (Σ₁ `⊎ Σ₂) (inj₂ xs₂) = □-map Σ₂ xs₂
+
+open Induction public

--- a/Agda_lib/LNDT.agda
+++ b/Agda_lib/LNDT.agda
@@ -1,13 +1,25 @@
 module LNDT where
 
 open import Dependencies.Imports
+open import GNDT
 open import SpreadAble
 
 -- The specification for linked lndt data types
 
-data LNDT {a} (F : TT) (A : Set a) : Set a where
-  [] : LNDT F A
-  _∷_ : A → LNDT F (F A) → LNDT F A
+Σ-LNDT : ∀ {a} → Sig a
+Σ-LNDT = `⊤ `⊎ (`A `× `X)
+
+LNDT : ∀ {a} (F : TT)(A : Set a) → Set a
+LNDT F A = GNDT Σ-LNDT F A
+
+nil : ∀ {a} {F : TT}{A : Set a} → LNDT F A
+nil = ctor (inj₁ (lift tt))
+
+cons : ∀ {a} {F : TT}{A : Set a} → A → LNDT F (F A) → LNDT F A
+cons a xs = ctor (inj₂ (a , xs))
+
+pattern [] = ctor (inj₁ (lift tt))
+pattern _∷_ a xs = ctor (inj₂ (a , xs))
 
 infixr 3 _∷_
 
@@ -19,8 +31,8 @@ lndt-ind : ∀
   (P[] : ∀ {a} {A : Set a} → P {A = A} [])
   (f   : ∀ {a} {A : Set a} (x : A) {l} → P l → P (x ∷ l))
   {a} {A : Set a} (x : LNDT F A) → P x
-lndt-ind     _ P[] _ []      = P[]
-lndt-ind {F} P P[] f (x ∷ e) = f x (lndt-ind {F} P P[] f e)
+lndt-ind {F} P P[] f x = gndt-ind {Σ = Σ-LNDT} P (λ { (inj₁ (lift tt)) (lift tt) → P[]
+                                                    ; (inj₂ (a , x)) (lift tt , px) → f a px }) x
 
 -- The depth of an instance of LNDT
 depth : ∀ {a} {F : TT} {A : Set a} → LNDT F A → ℕ


### PR DESCRIPTION
We can go beyond list-like containers now. This slight generalization
supports any kind of sum-of-product, first-order datatype. This could
be further extended to support Pi-types and Sigma-types, à la Desc
described in

  https://www.irif.fr/~dagand/stuffs/thesis-2011-phd/thesis.pdf